### PR TITLE
Fix crashes and bugs when both captains are put on a path

### DIFF
--- a/include/Drought/Pathfinder.h
+++ b/include/Drought/Pathfinder.h
@@ -35,6 +35,17 @@ struct Path {
 		}
 	}
 
+	void swap(Path& other) {
+		u16 tempL = mLength;
+		s16* tempW = mWaypointList;
+
+		mLength = other.mLength;
+		mWaypointList = other.mWaypointList;
+
+		other.mLength = tempL;
+		other.mWaypointList = tempW;
+	}
+
 	inline bool hasPath() const { return mLength != 0 && mWaypointList; }
 
 	void allocate(u16 size);

--- a/src/plugProjectDroughtU/GoHereNavi.cpp
+++ b/src/plugProjectDroughtU/GoHereNavi.cpp
@@ -10,6 +10,8 @@
 #include "Game/GameLight.h"
 #include "Game/CPlate.h"
 
+#define GO_HERE_NAVI_DEBUG (false)
+
 namespace Game {
 
 bool AreAllPikisBlue(Navi* navi)
@@ -98,16 +100,15 @@ void NaviGoHereState::init(Navi* player, StateArg* arg)
 {
 	P2ASSERT(arg);
 	NaviGoHereStateArg* goHereArg = static_cast<NaviGoHereStateArg*>(arg);
+	
 
 	player->startMotion(IPikiAnims::WALK, IPikiAnims::WALK, nullptr, nullptr);
 	player->setMoveRotation(true);
 
 	mTargetPosition = goHereArg->mPosition;
-	mPath.allocate(goHereArg->mPath.mLength);
-	for (u16 i = 0; i < goHereArg->mPath.mLength; ++i) {
-		mPath.mWaypointList[i] = goHereArg->mPath.mWaypointList[i];
-	}
 
+	mPath.swap(goHereArg->mPath);	
+	
 	mActiveRouteNodeIndex = 0;
 	mLastPosition         = player->getPosition();
 	mTimeoutTimer         = 0.0f;
@@ -428,9 +429,10 @@ void NaviGoHereState::changeState(Navi* player, bool isWanted)
 	PSSystem::spSysIF->playSystemSe(isWanted ? PSSE_SY_PLAYER_CHANGE : PSSE_PL_ORIMA_DAMAGE, 0);
 }
 
+
 void Navi::doDirectDraw(Graphics& gfx)
 {
-	return;
+#if GO_HERE_NAVI_DEBUG
 
 	if (getStateID() != NSID_GoHere) {
 		return;
@@ -444,6 +446,7 @@ void Navi::doDirectDraw(Graphics& gfx)
 	info.mColorA = Color4(0xC8, 0xC8, 0xFF, 0xC8);
 	info.mColorB = Color4(0x64, 0x64, 0xFF, 0xC8);
 	gfx.perspPrintf(info, pos, "[%d/%d] t[%1.1f]", state->mActiveRouteNodeIndex, state->mPath.mLength, state->mTimeoutTimer);
+#endif
 }
 
 bool Navi::canSwap()

--- a/src/plugProjectDroughtU/GoHereNavi.cpp
+++ b/src/plugProjectDroughtU/GoHereNavi.cpp
@@ -103,7 +103,10 @@ void NaviGoHereState::init(Navi* player, StateArg* arg)
 	player->setMoveRotation(true);
 
 	mTargetPosition = goHereArg->mPosition;
-	mPath           = goHereArg->mPath;
+	mPath.allocate(goHereArg->mPath.mLength);
+	for (u16 i = 0; i < goHereArg->mPath.mLength; ++i) {
+		mPath.mWaypointList[i] = goHereArg->mPath.mWaypointList[i];
+	}
 
 	mActiveRouteNodeIndex = 0;
 	mLastPosition         = player->getPosition();


### PR DESCRIPTION
If you set one captain on a path and then set the other captain on a path before the first captain's path completes, then the first captain's path will usually become messed up.

For example:

https://github.com/user-attachments/assets/cc46846e-6c36-47ed-92ac-278fb01a2945

It appears that the first captain now follows the second captain's path too, but still retains the correct destination position.

It may also crash when the second captain begins their path:

https://github.com/user-attachments/assets/69a384f9-967c-49c7-8a85-df06c8d76e5e

I \*think\* this happens because `NaviGoHereState::init()` initializes its own `mPath` by copying directly from `goHereArg->mPath`, which means copying the pointer value in `goHereArg->mPath.mWaypointList`.

I \*think\* `goHereArg` eventually gets freed or reused and then NaviGoHereState's `mPath.mWaypointList` holds a bad pointer.

This seems to be fixed by replacing the shallow assignment with a real clone copy:

```diff
  	mTargetPosition = goHereArg->mPosition;
- 	mPath = goHereArg->mPath;
+ 	mPath.allocate(goHereArg->mPath.mLength);
+ 	for (u16 i = 0; i < goHereArg->mPath.mLength; ++i) {
+ 		mPath.mWaypointList[i] = goHereArg->mPath.mWaypointList[i];
+ 	}
```

https://github.com/user-attachments/assets/839ebb99-9b3d-4345-90c1-94cc46cfe09f

I don't think any additional memory management to free the cloned copy is necessary, but I could absolutely be wrong, please fact check me!