### PR TITLE
Fix bug where Go Here is immediately cancelled if the A button or analog stick is held while the map is closing.

### DIFF
--- a/src/plugProjectDroughtU/GoHereNavi.cpp
+++ b/src/plugProjectDroughtU/GoHereNavi.cpp
@@ -100,15 +100,14 @@ void NaviGoHereState::init(Navi* player, StateArg* arg)
 {
 	P2ASSERT(arg);
 	NaviGoHereStateArg* goHereArg = static_cast<NaviGoHereStateArg*>(arg);
-	
 
 	player->startMotion(IPikiAnims::WALK, IPikiAnims::WALK, nullptr, nullptr);
 	player->setMoveRotation(true);
 
 	mTargetPosition = goHereArg->mPosition;
 
-	mPath.swap(goHereArg->mPath);	
-	
+	mPath.swap(goHereArg->mPath);
+
 	mActiveRouteNodeIndex = 0;
 	mLastPosition         = player->getPosition();
 	mTimeoutTimer         = 0.0f;
@@ -184,13 +183,13 @@ void NaviGoHereState::exec(Navi* player)
 		if (distanceBetweenLast <= 1.5f) {
 			mTimeoutTimer += sys->mDeltaTime;
 
-			// If the player presses a button, or we've been trying for a while, give up
-			bool isAnyInput = player->mController1 && player->mController1->isAnyInput();
-			if (isAnyInput || mTimeoutTimer >= 2.5f) {
-				// The player change sound triggers if input is pressed, otherwise the damage sound triggers
-				changeState(player, isAnyInput);
+			// If we've been trying for a while, give up
+			if (mTimeoutTimer >= 2.5f) {
+				changeState(player, false);
 				return;
 			}
+		} else {
+			mTimeoutTimer = 0.0f;
 		}
 	}
 
@@ -433,7 +432,6 @@ void NaviGoHereState::changeState(Navi* player, bool isWanted)
 void Navi::doDirectDraw(Graphics& gfx)
 {
 #if GO_HERE_NAVI_DEBUG
-
 	if (getStateID() != NSID_GoHere) {
 		return;
 	}


### PR DESCRIPTION
If the captain had traveled fewer than 1.5 units, the state would be cancelled if they had been "stuck" for more than 2.5 seconds or if any button is pressed.

The problem is that if a button is held (such as the A button or analog stick) while/when the map menu finishes closing, which is extremely easy and convenient to do, then it will immediately be true that the captain had traveled fewer than 1.5 units (they've traveled 0 units) and so the state will be cancelled despite never being "stuck".

I suggest simply removing the `isAnyInput` check.

I think the B button and the 2.5 second "stuck" timeout are sufficient. I don't think it's very useful to have "momentarily stuck + any input" as another method of cancelling.

I also added `else mTimeoutTimer = 0.0f` for any update where the captain does move more than 1.5 units, so that so that the "stuck" timeout triggers when the captain is _really_ stuck, instead of triggering due to a bunch of small accumulated snags.