### PR TITLE
Fix camera angle bug when both captains are in GoHere state

### DIFF
--- a/src/plugProjectDroughtU/GoHereNavi.cpp
+++ b/src/plugProjectDroughtU/GoHereNavi.cpp
@@ -166,7 +166,7 @@ void NaviGoHereState::exec(Navi* player)
 
 	// Update the camera angle
 	Vector3f playerPos = player->getPosition();
-	{
+	if (player->mNaviIndex == gameSystem->mSection->mCurrentPlayerIndex) {
 		static f32 currentAngle = roundAng(player->getFaceDir() + PI);
 		f32 targetAngle         = roundAng(player->getFaceDir() + PI);
 


### PR DESCRIPTION
If both captains are in a GoHere state, the camera would be "permanently stuck" halfway between two captain's facing angles, regardless of which captain is the active captain.

This is because `currentAngle` is static and therefore shared between them. Both of their updates attempt to interpolate the current angle towards their own target angle, causing the camera angle to always split the difference.

The fix is to only attempt to update the camera angle if the captain in question is the active captain. That way the static variable `currentAngle` only has one target angle at a time.